### PR TITLE
Fix regex escaping in TerminalNavigator

### DIFF
--- a/src/components/Terminal/TerminalNavigator.jsx
+++ b/src/components/Terminal/TerminalNavigator.jsx
@@ -91,7 +91,7 @@ export default function TerminalNavigator({ onReboot, setIsTearing, setIsShatter
   }, [lastActivity]);
 
   const escapeHTML = (str) =>
-    str.replace(/[&<>"]'/g, match => (
+    str.replace(/[&<>"']/g, match => (
       { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[match]
     ));
 


### PR DESCRIPTION
## Summary
- correct escapeHTML regex in TerminalNavigator

## Testing
- `npm test --silent` *(fails: Cannot find module 'react-router-dom')*
- Node escapeHTML check

------
https://chatgpt.com/codex/tasks/task_e_683ff07cae2c832b994c3d8df3b47990